### PR TITLE
Adds ID attribute to the list and list items.

### DIFF
--- a/src/List.js
+++ b/src/List.js
@@ -1,5 +1,6 @@
 'use strict';
 
+import core from 'metal';
 import dom from 'metal-dom';
 import Component from 'metal-component';
 import Soy from 'metal-soy';
@@ -35,6 +36,15 @@ Soy.register(List, templates);
  * @static
  */
 List.STATE = {
+	/**
+	 * A unique identifier for the component. It's also used to compound the
+	 * items' ID attribute unless if itemsHtml attribute is used.
+	 * @type {string}
+	 */
+	id: {
+		valueFn: () => 'list-component-' + core.getUid()
+	},
+
 	/**
 	 * The list items. Each is represented by an object that can have the following keys:
 	 *   - textPrimary: The item's main content.

--- a/src/List.soy
+++ b/src/List.soy
@@ -2,18 +2,20 @@
 
 /**
  * This renders the main element
+ * @param id
  * @param? elementClasses
  * @param? items
  */
 {template .render}
 	{@param? itemsHtml: html}
 	<div class="list{$elementClasses ? ' ' + $elementClasses : ''}">
-		<ul class="list-group" data-onclick="handleClick" role="list">
+		<ul class="list-group" data-onclick="handleClick" id="{$id}" role="list">
 			{if isNonnull($itemsHtml)}
 				{$itemsHtml}
 			{else}
 				{foreach $item in $items}
 					{call ListItem.render}
+						{param id: $id + '-item-' + (index($item) + 1) /}
 						{param index: index($item) /}
 						{param item: $item /}
 						{param key: '-items-' + index($item) /}

--- a/src/ListItem.js
+++ b/src/ListItem.js
@@ -39,6 +39,14 @@ Soy.register(ListItem, templates);
  */
 ListItem.STATE = {
 	/**
+	 * A unique identifier for each item.
+	 * @type {string}
+	 */
+	id: {
+		valueFn: () => 'list-component-item' + core.getUid()
+	},
+
+	/**
 	 * The item to be rendered.
 	 * @type {!Object}
 	 */

--- a/src/ListItem.soy
+++ b/src/ListItem.soy
@@ -1,13 +1,14 @@
 {namespace ListItem}
 
 /**
+ * @param id
  * @param index
  * @param item
  * @param? elementClasses
  */
 {template .render}
 	<li class="listitem list-group-item {$elementClasses ? ' ' + $elementClasses : ''} clearfix"
-		data-index="{$index}" role="listitem">
+		data-index="{$index}" id="{$id}" role="listitem">
 		{if $item.avatar}
 			<span class="list-image pull-left {$item.avatar.class}">
 				{$item.avatar.content}

--- a/test/List.js
+++ b/test/List.js
@@ -164,4 +164,68 @@ describe('List', function() {
 
 		dom.triggerEvent(elements[1].childNodes[0], 'click');
 	});
+
+	it('should create an ID attribute in order to other componet could use it', function() {
+		list = new List({
+			items: [{
+				textPrimary: 'Item 1'
+			}, {
+				textPrimary: 'Item 2'
+			}]
+		});
+
+		assert.ok(list.element.querySelector('ul').hasAttribute('id'));
+	});
+
+	it('should create an ID to each item in order to other componet could use it', function() {
+		list = new List({
+			items: [{
+				textPrimary: 'Item 1'
+			}, {
+				textPrimary: 'Item 2'
+			}]
+		});
+
+		var elements = list.element.querySelectorAll('li');
+
+		assert.ok(elements[0].hasAttribute('id'));
+		assert.ok(elements[1].hasAttribute('id'));
+	});
+
+	it('should not create the same ID to its items', function() {
+		list = new List({
+			items: [{
+				textPrimary: 'Item 1'
+			}, {
+				textPrimary: 'Item 2'
+			}]
+		});
+
+		var elements = list.element.querySelectorAll('li');
+
+		assert.notEqual(elements[0].getAttribute('id'), elements[1].getAttribute('id'));
+	});
+
+	it('should not create the same ID for two instances', function() {
+		list = new List({
+			items: [{
+				textPrimary: 'Item 1'
+			}, {
+				textPrimary: 'Item 2'
+			}]
+		});
+
+		var list2 = new List({
+			items: [{
+				textPrimary: 'Item 1'
+			}, {
+				textPrimary: 'Item 2'
+			}]
+		});
+
+		assert.notEqual(
+			list.element.querySelector('ul').getAttribute('id'),
+			list2.element.querySelector('ul').getAttribute('id')
+		);
+	});
 });


### PR DESCRIPTION
This is necessary for applying some accessibilities features. This is required for accomplishing this issue https://github.com/metal/metal-autocomplete/issues/4, for example.

To make the autocomplete component accessible by keyboard inputs, we should use aria-owns and aria-activedescendant attributes in order to refer the list of suggestions and the currently focused suggestion option respectively. Both those accessibility attributes receive the element ID as value.